### PR TITLE
fix: dashboard heading and import wizard redirect (#2, #3)

### DIFF
--- a/app/src/main/java/com/ryan/pollenwitan/data/location/GpsLocationProvider.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/location/GpsLocationProvider.kt
@@ -71,6 +71,6 @@ class GpsLocationProvider(private val context: Context) {
     private fun Location.toAppLocation() = AppLocation(
         latitude = latitude,
         longitude = longitude,
-        displayName = "GPS Location"
+        displayName = "%.4f, %.4f".format(latitude, longitude)
     )
 }

--- a/app/src/main/java/com/ryan/pollenwitan/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/navigation/AppNavGraph.kt
@@ -36,8 +36,10 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
@@ -121,9 +123,14 @@ fun AppNavGraph(
     val scope = rememberCoroutineScope()
     val colors = ForestTheme.current
 
-    // Redirect to onboarding if no profiles exist
+    // Redirect to onboarding if no profiles exist on first run.
+    // hasHadProfiles prevents mid-session redirects (e.g. while import is clearing data).
+    var hasHadProfiles by remember { mutableStateOf(false) }
     LaunchedEffect(profiles) {
-        if (profiles != null && profiles!!.isEmpty()) {
+        val currentProfiles = profiles ?: return@LaunchedEffect
+        if (currentProfiles.isNotEmpty()) {
+            hasHadProfiles = true
+        } else if (!hasHadProfiles) {
             navController.navigate(Screen.Onboarding.route) {
                 popUpTo(Screen.Dashboard.route) { inclusive = true }
             }

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/DashboardScreen.kt
@@ -140,10 +140,17 @@ private fun DashboardContent(
     ) {
         // Header
         Text(
-            text = locationDisplayName.ifEmpty { stringResource(R.string.common_loading) },
+            text = selectedProfile?.displayName ?: locationDisplayName.ifEmpty { stringResource(R.string.common_loading) },
             style = MaterialTheme.typography.headlineMedium,
             fontWeight = FontWeight.Bold
         )
+        if (selectedProfile != null && locationDisplayName.isNotEmpty()) {
+            Text(
+                text = locationDisplayName,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
         Text(
             text = stringResource(R.string.dashboard_current_conditions, conditions.timestamp.format(DateTimeFormatter.ofPattern("EEEE d MMMM, HH:mm"))),
             style = MaterialTheme.typography.bodyMedium,


### PR DESCRIPTION
## Summary

- **#2 — Dashboard heading**: The heading now shows the selected profile's display name (e.g. "Ryan") instead of the location. The location is demoted to a dimmed subtitle. GPS display name is now actual coordinates (`52.4064, 16.9252`) rather than the hardcoded string "GPS Location".
- **#3 — Import redirects to onboarding**: Import is destructive (deletes then restores profiles), which briefly emptied the profile list mid-session and triggered the onboarding redirect. A `hasHadProfiles` flag in `AppNavGraph` now ensures the redirect only fires on true first-run.

## Files changed

- `DashboardScreen.kt` — heading uses profile name; location shown as subtitle
- `GpsLocationProvider.kt` — GPS display name uses formatted coordinates
- `AppNavGraph.kt` — `hasHadProfiles` guard prevents mid-session onboarding redirect

## Test plan

- [ ] Open the dashboard with a profile selected — heading should show the profile name, location name below it
- [ ] With GPS mode active, verify the location subtitle shows coordinates, not "GPS Location"
- [ ] Go to Settings → Import, import a JSON backup — verify you stay on Settings after import completes and are not redirected to onboarding

https://claude.ai/code/session_019CZ3sLukjnTEWkzYCRqg82