### PR TITLE
feat: add Useful Information screen (issue #4)

### DIFF
--- a/app/src/main/java/com/ryan/pollenwitan/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/navigation/AppNavGraph.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.EditNote
 import androidx.compose.material.icons.filled.EventNote
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Person
@@ -70,6 +71,7 @@ import com.ryan.pollenwitan.ui.screens.ProfileListScreen
 import com.ryan.pollenwitan.ui.screens.SettingsScreen
 import com.ryan.pollenwitan.ui.screens.AllergenDiscoveryScreen
 import com.ryan.pollenwitan.ui.screens.ThresholdCalibrationScreen
+import com.ryan.pollenwitan.ui.screens.UsefulInfoScreen
 import com.ryan.pollenwitan.R
 import com.ryan.pollenwitan.ui.theme.ForestTheme
 import androidx.annotation.StringRes
@@ -88,6 +90,7 @@ private val navItems = listOf(
     NavItem(Screen.ProfileList, R.string.nav_profiles, Icons.Filled.Person),
     NavItem(Screen.CrossReactivity, R.string.nav_cross_reactivity, Icons.Filled.Link),
     NavItem(Screen.PollenCalendar, R.string.nav_pollen_calendar, Icons.Filled.EventNote),
+    NavItem(Screen.UsefulInfo, R.string.nav_useful_info, Icons.Filled.Info),
     NavItem(Screen.SymptomDiary, R.string.nav_symptom_diary, Icons.Filled.EditNote),
     NavItem(Screen.SymptomTrends, R.string.nav_symptom_trends, Icons.Filled.Timeline),
     NavItem(Screen.Settings, R.string.nav_settings, Icons.Filled.Settings)
@@ -329,6 +332,7 @@ fun AppNavGraph(
                 composable(Screen.Forecast.route) { ForecastScreen() }
                 composable(Screen.CrossReactivity.route) { CrossReactivityScreen() }
                 composable(Screen.PollenCalendar.route) { PollenCalendarScreen() }
+                composable(Screen.UsefulInfo.route) { UsefulInfoScreen() }
                 composable(
                     Screen.SymptomCheckIn.route,
                     arguments = listOf(navArgument("date") {

--- a/app/src/main/java/com/ryan/pollenwitan/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/navigation/Screen.kt
@@ -11,6 +11,7 @@ sealed class Screen(val route: String) {
     }
     data object CrossReactivity : Screen("cross-reactivity")
     data object PollenCalendar : Screen("pollen-calendar")
+    data object UsefulInfo : Screen("useful-info")
     data object SymptomCheckIn : Screen("symptom-checkin?date={date}") {
         fun createRoute(date: String? = null) =
             if (date != null) "symptom-checkin?date=$date" else "symptom-checkin"

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/UsefulInfoScreen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/UsefulInfoScreen.kt
@@ -1,0 +1,140 @@
+package com.ryan.pollenwitan.ui.screens
+
+import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.ryan.pollenwitan.R
+
+@Composable
+fun UsefulInfoScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.info_title),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = stringResource(R.string.info_intro),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        InfoSection(
+            titleRes = R.string.info_allergies_title,
+            contentRes = R.string.info_allergies_body
+        )
+
+        InfoSection(
+            titleRes = R.string.info_specificity_title,
+            contentRes = R.string.info_specificity_body,
+            footnoteRes = R.string.info_specificity_cross_reactivity_link
+        )
+
+        InfoSection(
+            titleRes = R.string.info_medication_title,
+            contentRes = R.string.info_medication_body
+        )
+
+        InfoSection(
+            titleRes = R.string.info_features_title,
+            contentRes = R.string.info_features_body
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun InfoSection(
+    @StringRes titleRes: Int,
+    @StringRes contentRes: Int,
+    @StringRes footnoteRes: Int? = null
+) {
+    var expanded by remember { mutableStateOf(true) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { expanded = !expanded },
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(titleRes),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f)
+                )
+                Icon(
+                    imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            AnimatedVisibility(visible = expanded) {
+                Column {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(contentRes),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    if (footnoteRes != null) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = stringResource(footnoteRes),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -264,6 +264,20 @@
     <string name="calendar_legend_off_season">Poza sezonem</string>
     <string name="calendar_disclaimer">Daty są przybliżone i oparte na typowych danych aerobiologicznych dla Europy Środkowej. Rzeczywisty termin sezonu różni się w zależności od roku i warunków pogodowych.</string>
 
+    <!-- Useful Information -->
+    <string name="nav_useful_info">Przydatne informacje</string>
+    <string name="info_title">Przydatne informacje</string>
+    <string name="info_intro">Dowiedz się, jak działają alergie, dlaczego ta aplikacja śledzi poszczególne rodzaje pyłków i jak najlepiej wykorzystać jej funkcje.</string>
+    <string name="info_allergies_title">Jak działają alergie</string>
+    <string name="info_allergies_body">Kiedy wdychasz pyłek, Twój układ odpornościowy może błędnie potraktować go jako zagrożenie. Produkuje przeciwciała IgE, które powodują uwalnianie histaminy. Histamina wywołuje znane objawy \u2014 kichanie, swędzące oczy, katar i zatkany nos. Dlatego leki antyhistaminowe pomagają: blokują działanie histaminy na Twoje komórki.</string>
+    <string name="info_specificity_title">Dlaczego rodzaj pyłku ma znaczenie</string>
+    <string name="info_specificity_body">Różne rodzaje pyłków osiągają szczyt w różnych porach roku \u2014 pyłki drzew wiosną, trawy wczesnym latem, a chwasty jak bylica i ambrozja późnym latem. Ich zasięg geograficzny również się znacznie różni. Wiedza o tym, które pyłki wywołują Twoje objawy, pozwala przygotować się na właściwe sezony i zignorować te, które Ci nie szkodzą.</string>
+    <string name="info_specificity_cross_reactivity_link">Niektóre pyłki dzielą białka i mogą reagować krzyżowo ze sobą lub z niektórymi pokarmami. Zobacz ekran Reakcji krzyżowych w menu nawigacji po pełny przewodnik.</string>
+    <string name="info_medication_title">Leki zapobiegawczo vs na objawy</string>
+    <string name="info_medication_body">Leki antyhistaminowe i spraye do nosa działają najlepiej, gdy przyjmiesz je przed ekspozycją na alergen, a nie po wystąpieniu objawów. Przyjęcie leku rano \u2014 zanim poziom pyłków osiągnie szczyt \u2014 daje czas na zbudowanie ochrony. Poranne powiadomienie jest zaprojektowane tak, aby to wspierać: informuje Cię, jak wygląda dzień, abyś mógł leczyć się zapobiegawczo.</string>
+    <string name="info_features_title">Zaawansowane funkcje</string>
+    <string name="info_features_body">Adaptacyjne progi: Po kilku tygodniach rejestrowania objawów użyj kalibracji progów (w profilu), aby dostosować moment ostrzeżeń do Twojej rzeczywistej wrażliwości.\n\nŚledzenie leków: Dodaj leki w Ustawieniach, przypisz je do profili i ustaw godziny przypomnień. Pulpit pokazuje dzienny postęp dawkowania.\n\nTryb odkrywania alergenów: Nie wiesz, na co jesteś uczulony? Włącz tryb odkrywania podczas tworzenia profilu. Aplikacja będzie śledzić wszystkie sześć rodzajów pyłków w porównaniu z Twoim dziennikiem objawów i zasugeruje, które z nich korelują z Twoimi złymi dniami.</string>
+
     <!-- Symptoms -->
     <string name="symptom_sneezing">Kichanie</string>
     <string name="symptom_itchy_watery_eyes">Swędzące/łzawiące oczy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,20 @@
     <string name="calendar_legend_off_season">Off season</string>
     <string name="calendar_disclaimer">Dates are approximate and based on typical aerobiological data for Central Europe. Actual season timing varies by year and weather conditions.</string>
 
+    <!-- Useful Information -->
+    <string name="nav_useful_info">Useful Information</string>
+    <string name="info_title">Useful Information</string>
+    <string name="info_intro">Learn how allergies work, why this app tracks pollen types individually, and how to get the most out of its features.</string>
+    <string name="info_allergies_title">How Allergies Work</string>
+    <string name="info_allergies_body">When you breathe in pollen, your immune system can mistakenly treat it as a threat. It produces antibodies called IgE, which trigger cells to release histamine. Histamine causes the familiar symptoms \u2014 sneezing, itchy eyes, runny nose, and congestion. This is why antihistamines help: they block histamine from reaching your cells.</string>
+    <string name="info_specificity_title">Why Pollen Type Matters</string>
+    <string name="info_specificity_body">Different pollen types peak in different seasons \u2014 tree pollens in spring, grasses in early summer, and weeds like mugwort and ragweed in late summer. Their geographic ranges also vary widely. Knowing exactly which pollens trigger your symptoms lets you prepare for the right seasons and ignore the noise from pollens that don\u2019t affect you.</string>
+    <string name="info_specificity_cross_reactivity_link">Some pollens share proteins and can cross-react with each other or with certain foods. See the Cross-Reactivity screen in the navigation menu for the full guide.</string>
+    <string name="info_medication_title">Proactive vs Reactive Medication</string>
+    <string name="info_medication_body">Antihistamines and nasal sprays work best when taken before exposure, not after symptoms have already started. Taking your medication in the morning \u2014 before pollen levels peak \u2014 gives it time to build up protection. The morning briefing notification is designed to support this: it tells you what the day looks like so you can medicate proactively.</string>
+    <string name="info_features_title">Advanced Features</string>
+    <string name="info_features_body">Adaptive Thresholds: After logging symptoms for a couple of weeks, use Threshold Calibration (in your profile) to fine-tune when the app warns you, based on your actual sensitivity.\n\nMedication Tracker: Add medicines in Settings, assign them to profiles, and set reminder times. The dashboard shows your daily dose progress.\n\nAllergen Discovery Mode: Not sure what you\u2019re allergic to? Enable Discovery Mode when creating a profile. The app will track all six pollen types against your symptom diary and suggest which ones correlate with your bad days.</string>
+
     <!-- Symptoms -->
     <string name="symptom_sneezing">Sneezing</string>
     <string name="symptom_itchy_watery_eyes">Itchy/watery eyes</string>


### PR DESCRIPTION
## Summary
- Adds a new "Useful Information" screen with four expandable educational sections:
  1. How allergies work (IgE, histamine, antihistamines)
  2. Why pollen type matters (seasons, geographic ranges, cross-reactivity reference)
  3. Proactive vs reactive medication (morning briefing tie-in)
  4. Advanced features tour (threshold calibration, medication tracker, discovery mode)
- Wired into navigation drawer between Pollen Calendar and Symptom Diary (grouping educational screens together)
- English and Polish string resources (Polish translations are draft — native speaker review recommended)
- No ViewModel — pure static content following the CrossReactivityScreen pattern

Closes #4

## Test plan
- [ ] Verify screen appears in drawer at correct position (after Pollen Calendar)
- [ ] Verify all four sections render and expand/collapse correctly
- [ ] Verify Polish translation displays when language is set to Polish
- [ ] Verify cross-reactivity footnote text is visible in section 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)