### PR TITLE
feat: add legal disclaimer screen (issue #8)

### DIFF
--- a/app/src/main/java/com/ryan/pollenwitan/data/repository/LegalPrefsRepository.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/repository/LegalPrefsRepository.kt
@@ -1,0 +1,40 @@
+package com.ryan.pollenwitan.data.repository
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.legalPrefsDataStore by preferencesDataStore(name = "legal_prefs")
+
+class LegalPrefsRepository(
+    private val context: Context
+) {
+
+    private val dataStore get() = context.legalPrefsDataStore
+
+    private object Keys {
+        val LEGAL_ACCEPTED = booleanPreferencesKey("legal_accepted")
+        val LEGAL_ACCEPTED_VERSION = intPreferencesKey("legal_accepted_version")
+    }
+
+    fun isDisclaimerAccepted(): Flow<Boolean> = dataStore.data.map { prefs ->
+        val accepted = prefs[Keys.LEGAL_ACCEPTED] ?: false
+        val version = prefs[Keys.LEGAL_ACCEPTED_VERSION] ?: 0
+        accepted && version == CURRENT_DISCLAIMER_VERSION
+    }
+
+    suspend fun acceptDisclaimer() {
+        dataStore.edit {
+            it[Keys.LEGAL_ACCEPTED] = true
+            it[Keys.LEGAL_ACCEPTED_VERSION] = CURRENT_DISCLAIMER_VERSION
+        }
+    }
+
+    companion object {
+        const val CURRENT_DISCLAIMER_VERSION = 1
+    }
+}

--- a/app/src/main/java/com/ryan/pollenwitan/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/navigation/AppNavGraph.kt
@@ -56,6 +56,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.ryan.pollenwitan.data.repository.LegalPrefsRepository
 import com.ryan.pollenwitan.data.repository.ProfileRepository
 import com.ryan.pollenwitan.ui.screens.CrossReactivityScreen
 import com.ryan.pollenwitan.ui.screens.PollenCalendarScreen
@@ -69,6 +70,7 @@ import com.ryan.pollenwitan.ui.screens.ProfileEditScreen
 import com.ryan.pollenwitan.ui.screens.ProfileListScreen
 import com.ryan.pollenwitan.ui.screens.SettingsScreen
 import com.ryan.pollenwitan.ui.screens.AllergenDiscoveryScreen
+import com.ryan.pollenwitan.ui.screens.LegalDisclaimerScreen
 import com.ryan.pollenwitan.ui.screens.ThresholdCalibrationScreen
 import com.ryan.pollenwitan.R
 import com.ryan.pollenwitan.ui.theme.ForestTheme
@@ -101,10 +103,12 @@ fun AppNavGraph(
 ) {
     val context = LocalContext.current
     val profileRepository = remember { ProfileRepository(context.applicationContext) }
+    val legalPrefsRepository = remember { LegalPrefsRepository(context.applicationContext) }
     val profiles by profileRepository.getProfiles().collectAsStateWithLifecycle(initialValue = null)
+    val legalAccepted by legalPrefsRepository.isDisclaimerAccepted().collectAsStateWithLifecycle(initialValue = null)
 
     // Loading guard — wait for DataStore to initialize
-    if (profiles == null) return
+    if (profiles == null || legalAccepted == null) return
 
     val navController = rememberNavController()
 
@@ -123,10 +127,21 @@ fun AppNavGraph(
     val scope = rememberCoroutineScope()
     val colors = ForestTheme.current
 
+    // Redirect to legal disclaimer if not yet accepted (or version changed).
+    LaunchedEffect(legalAccepted) {
+        if (legalAccepted == false) {
+            navController.navigate(Screen.LegalDisclaimer.route) {
+                popUpTo(Screen.Dashboard.route) { inclusive = true }
+            }
+        }
+    }
+
     // Redirect to onboarding if no profiles exist on first run.
     // hasHadProfiles prevents mid-session redirects (e.g. while import is clearing data).
+    // Only check after legal disclaimer is accepted.
     var hasHadProfiles by remember { mutableStateOf(false) }
-    LaunchedEffect(profiles) {
+    LaunchedEffect(profiles, legalAccepted) {
+        if (legalAccepted != true) return@LaunchedEffect
         val currentProfiles = profiles ?: return@LaunchedEffect
         if (currentProfiles.isNotEmpty()) {
             hasHadProfiles = true
@@ -151,11 +166,11 @@ fun AppNavGraph(
     }
     val currentLabel = stringResource(currentLabelRes)
 
-    val isOnboarding = currentRoute == Screen.Onboarding.route
+    val isFullScreen = currentRoute == Screen.Onboarding.route || currentRoute == Screen.LegalDisclaimer.route
 
     ModalNavigationDrawer(
         drawerState = drawerState,
-        gesturesEnabled = !isOnboarding,
+        gesturesEnabled = !isFullScreen,
         drawerContent = {
             ModalDrawerSheet(
                 drawerContainerColor = colors.Mid,
@@ -276,7 +291,7 @@ fun AppNavGraph(
                 .safeDrawingPadding(),
             containerColor = colors.Dark,
             topBar = {
-                if (!isOnboarding) {
+                if (!isFullScreen) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -307,6 +322,15 @@ fun AppNavGraph(
                 startDestination = Screen.Dashboard.route,
                 modifier = Modifier.padding(innerPadding)
             ) {
+                composable(Screen.LegalDisclaimer.route) {
+                    LegalDisclaimerScreen(
+                        onAccepted = {
+                            navController.navigate(Screen.Dashboard.route) {
+                                popUpTo(Screen.LegalDisclaimer.route) { inclusive = true }
+                            }
+                        }
+                    )
+                }
                 composable(Screen.Onboarding.route) {
                     OnboardingScreen(
                         onFinished = {

--- a/app/src/main/java/com/ryan/pollenwitan/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/navigation/Screen.kt
@@ -20,6 +20,7 @@ sealed class Screen(val route: String) {
     data object ThresholdCalibration : Screen("profiles/{profileId}/calibrate") {
         fun createRoute(profileId: String) = "profiles/$profileId/calibrate"
     }
+    data object LegalDisclaimer : Screen("legal-disclaimer")
     data object Onboarding : Screen("onboarding")
     data object AllergenDiscovery : Screen("profiles/{profileId}/discovery") {
         fun createRoute(profileId: String) = "profiles/$profileId/discovery"

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/LegalDisclaimerScreen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/LegalDisclaimerScreen.kt
@@ -1,0 +1,143 @@
+package com.ryan.pollenwitan.ui.screens
+
+import android.app.Activity
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.ryan.pollenwitan.R
+import com.ryan.pollenwitan.data.repository.LegalPrefsRepository
+import com.ryan.pollenwitan.ui.theme.ForestTheme
+import kotlinx.coroutines.launch
+
+@Composable
+fun LegalDisclaimerScreen(onAccepted: () -> Unit) {
+    val context = LocalContext.current
+    val repository = remember { LegalPrefsRepository(context.applicationContext) }
+    val scope = rememberCoroutineScope()
+    val colors = ForestTheme.current
+    val listState = rememberLazyListState()
+
+    val isAtBottom by remember {
+        derivedStateOf {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+            lastVisible != null && lastVisible.index == listState.layoutInfo.totalItemsCount - 1
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.legal_title),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = stringResource(R.string.legal_intro),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+        ) {
+            item { DisclaimerSection(R.string.legal_not_medical_advice_title, R.string.legal_not_medical_advice_body) }
+            item { DisclaimerSection(R.string.legal_data_accuracy_title, R.string.legal_data_accuracy_body) }
+            item { DisclaimerSection(R.string.legal_liability_title, R.string.legal_liability_body) }
+            item { DisclaimerSection(R.string.legal_privacy_title, R.string.legal_privacy_body) }
+            item { DisclaimerSection(R.string.legal_attribution_title, R.string.legal_attribution_body) }
+            item { Spacer(modifier = Modifier.height(8.dp)) }
+        }
+
+        if (!isAtBottom) {
+            Text(
+                text = stringResource(R.string.legal_scroll_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = colors.TextDim,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(vertical = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            OutlinedButton(
+                onClick = { (context as Activity).finishAffinity() }
+            ) {
+                Text(stringResource(R.string.legal_disagree))
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(
+                enabled = isAtBottom,
+                onClick = {
+                    scope.launch {
+                        repository.acceptDisclaimer()
+                        onAccepted()
+                    }
+                }
+            ) {
+                Text(stringResource(R.string.legal_agree))
+            }
+        }
+    }
+}
+
+@Composable
+private fun DisclaimerSection(
+    @StringRes titleRes: Int,
+    @StringRes bodyRes: Int
+) {
+    Column(modifier = Modifier.padding(vertical = 8.dp)) {
+        Text(
+            text = stringResource(titleRes),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = stringResource(bodyRes),
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -417,6 +417,23 @@
     <string name="discovery_done_explanation">Tryb odkrywania jest aktywny. Wszystkie typy pyłków będą wyświetlane na pulpicie. Zapisuj objawy co wieczór, aby zebrać dane do analizy.</string>
     <string name="discovery_done_tip">Wskazówka: Potrzebujesz co najmniej 14 wpisów w dzienniku, aby analiza odkrywania dała wyniki. Im więcej danych zapiszesz, tym dokładniejsze będą wyniki.</string>
 
+    <!-- Legal Disclaimer -->
+    <string name="legal_title">Zastrzeżenia prawne</string>
+    <string name="legal_intro">Proszę uważnie przeczytać poniższe informacje przed korzystaniem z PollenWitan.</string>
+    <string name="legal_not_medical_advice_title">To nie jest porada medyczna</string>
+    <string name="legal_not_medical_advice_body">PollenWitan jest wyłącznie narzędziem informacyjnym. Nie udziela porad medycznych, nie stawia diagnoz ani nie zaleca leczenia. Prognozy pyłków, wyniki odkrywania alergenów, sugestie kalibracji progów i informacje o reakcjach krzyżowych opierają się na modelach statystycznych i ogólnych danych \u2014 nie zastępują profesjonalnej porady medycznej. Zawsze konsultuj się z wykwalifikowanym alergologiem lub lekarzem w sprawie diagnostyki, decyzji terapeutycznych i zarządzania lekami.</string>
+    <string name="legal_data_accuracy_title">Dokładność danych</string>
+    <string name="legal_data_accuracy_body">Dane o pyłkach i jakości powietrza pochodzą z europejskiego modelu Copernicus Atmosphere Monitoring Service (CAMS) za pośrednictwem API Open-Meteo. Dane te mają rozdzielczość około 11 km i opierają się na modelowaniu atmosferycznym, a nie na bezpośrednich pomiarach lokalnych. Rzeczywiste poziomy pyłków w Twojej dokładnej lokalizacji mogą różnić się od prognozy. Aplikacja jest przeznaczona wyłącznie dla lokalizacji europejskich; dane spoza Europy mogą być niedostępne lub niewiarygodne.</string>
+    <string name="legal_liability_title">Ograniczenie odpowiedzialności</string>
+    <string name="legal_liability_body">PollenWitan jest udostępniany \u201Etak jak jest\u201D, bez jakiejkolwiek gwarancji. Deweloper nie ponosi odpowiedzialności za jakiekolwiek szkody zdrowotne lub inne wynikające z korzystania z tej aplikacji lub polegania na niej, w tym między innymi za pominięte powiadomienia, niedokładne prognozy lub decyzje dotyczące leków podjęte na podstawie informacji z aplikacji.</string>
+    <string name="legal_privacy_title">Prywatność</string>
+    <string name="legal_privacy_body">Wszystkie dane osobowe \u2014 w tym profile, wpisy w dzienniku objawów, zapisy o lekach i preferencje \u2014 są przechowywane lokalnie na Twoim urządzeniu. Żadne dane osobowe nie są przesyłane na żaden serwer. Jedyne zapytania sieciowe kierowane są do API Open-Meteo, które otrzymuje Twoje współrzędne lokalizacji (szerokość i długość geograficzną) w celu pobrania danych prognostycznych. Nie jest wymagane żadne konto, rejestracja ani dane identyfikacyjne.</string>
+    <string name="legal_attribution_title">Atrybucja danych</string>
+    <string name="legal_attribution_body">Dane pogodowe i o jakości powietrza dostarczane przez Open-Meteo (https://open-meteo.com/). Dane o pyłkach pochodzą z Copernicus Atmosphere Monitoring Service (CAMS) \u2014 \u00A9 European Centre for Medium-Range Weather Forecasts (ECMWF). Licencja CC BY 4.0.</string>
+    <string name="legal_agree">Zgadzam się</string>
+    <string name="legal_disagree">Nie zgadzam się</string>
+    <string name="legal_scroll_hint">Przewiń w dół, aby przeczytać całe zastrzeżenie</string>
+
     <!-- About -->
     <string name="about_title">PollenWitan</string>
     <string name="about_description">Prognoza pyłków i jakości powietrza z poszanowaniem prywatności, dostosowana do konkretnych alergenów każdego domownika. Śledź sześć typów pyłków indywidualnie, zapisuj codzienne objawy, monitoruj przyjmowanie leków i sprawdzaj, które pyłki wpływają na Ciebie najbardziej dzięki analizie długoterminowych trendów. Bez reklam, bez śledzenia, bez kont.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,6 +419,23 @@
     <string name="discovery_done_explanation">Discovery mode is active. All pollen types will be displayed on your dashboard. Log your symptoms every evening to build up data for analysis.</string>
     <string name="discovery_done_tip">Tip: You need at least 14 diary entries for the discovery analysis to produce results. The more data you log, the more accurate the results will be.</string>
 
+    <!-- Legal Disclaimer -->
+    <string name="legal_title">Legal Disclaimer</string>
+    <string name="legal_intro">Please read the following carefully before using PollenWitan.</string>
+    <string name="legal_not_medical_advice_title">Not Medical Advice</string>
+    <string name="legal_not_medical_advice_body">PollenWitan is an informational tool only. It does not provide medical advice, diagnosis, or treatment. Pollen forecasts, allergen discovery results, threshold calibration suggestions, and cross-reactivity information are based on statistical models and general data \u2014 they are not a substitute for professional medical advice. Always consult a qualified allergist or healthcare provider for diagnosis, treatment decisions, and medication management.</string>
+    <string name="legal_data_accuracy_title">Data Accuracy</string>
+    <string name="legal_data_accuracy_body">Pollen and air quality data is sourced from the Copernicus Atmosphere Monitoring Service (CAMS) European model via the Open-Meteo API. This data has a resolution of approximately 11 km and is based on atmospheric modelling, not direct local measurements. Actual pollen levels at your exact location may differ from the forecast. The app is designed for European locations only; data outside Europe may be unavailable or unreliable.</string>
+    <string name="legal_liability_title">Limitation of Liability</string>
+    <string name="legal_liability_body">PollenWitan is provided \u201Cas is\u201D without warranty of any kind. The developer is not liable for any harm, health outcomes, or damages arising from the use of or reliance on this app, including but not limited to missed notifications, inaccurate forecasts, or medication-related decisions made based on the app\u2019s information.</string>
+    <string name="legal_privacy_title">Privacy</string>
+    <string name="legal_privacy_body">All personal data \u2014 including profiles, symptom diary entries, medication records, and preferences \u2014 is stored locally on your device. No personal data is transmitted to any server. The only network requests are to the Open-Meteo API, which receives your location coordinates (latitude and longitude) to retrieve forecast data. No account, registration, or identifying information is required.</string>
+    <string name="legal_attribution_title">Data Attribution</string>
+    <string name="legal_attribution_body">Weather and air quality data provided by Open-Meteo (https://open-meteo.com/). Pollen data sourced from the Copernicus Atmosphere Monitoring Service (CAMS) \u2014 \u00A9 European Centre for Medium-Range Weather Forecasts (ECMWF). Licensed under CC BY 4.0.</string>
+    <string name="legal_agree">I Agree</string>
+    <string name="legal_disagree">Disagree</string>
+    <string name="legal_scroll_hint">Scroll down to read the full disclaimer</string>
+
     <!-- About -->
     <string name="about_title">PollenWitan</string>
     <string name="about_description">A privacy-respecting pollen and air quality forecast tailored to each household member\u2019s specific allergenic triggers. Track six pollen types individually, log daily symptoms, monitor medication adherence, and identify which pollens affect you most through long-term trend analysis. No ads, no tracking, no accounts.</string>


### PR DESCRIPTION
## Summary
- Adds a mandatory legal disclaimer screen shown on first launch, before onboarding
- Five sections: Not Medical Advice, Data Accuracy, Limitation of Liability, Privacy, Data Attribution
- Scroll-to-bottom enforcement — "I Agree" button is disabled until the user scrolls to the end
- "Disagree" closes the app via `finishAffinity()`
- Acceptance persisted in DataStore with a version int (`CURRENT_DISCLAIMER_VERSION = 1`) — increment to re-show on text changes
- Navigation gate in `AppNavGraph` fires before the onboarding redirect
- Drawer and top bar hidden on the disclaimer screen (same pattern as onboarding)
- English and Polish string resources (Polish translations are draft — native speaker review recommended)

### New files
- `LegalPrefsRepository.kt` — DataStore persistence for acceptance state
- `LegalDisclaimerScreen.kt` — Full-screen composable with `LazyColumn` scroll tracking

### Modified files
- `Screen.kt` — added `LegalDisclaimer` route
- `AppNavGraph.kt` — legal redirect, composable route, `isFullScreen` guard, onboarding gated behind legal acceptance

Closes #8

## Test plan
- [ ] Fresh install: legal disclaimer appears before onboarding
- [ ] Scroll enforcement: "I Agree" is disabled until scrolled to bottom
- [ ] Accept: persists across app restarts, goes to onboarding (if no profiles) or dashboard
- [ ] Disagree: app closes cleanly
- [ ] Version bump test: change `CURRENT_DISCLAIMER_VERSION` to 2, disclaimer re-appears
- [ ] Existing users: disclaimer shows on first launch after update (no prior acceptance stored)
- [ ] Notification deep links still work after acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)