### PR TITLE
fix: remove phantom dot on empty diary progress bar

### DIFF
--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/AllergenDiscoveryScreen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/AllergenDiscoveryScreen.kt
@@ -204,6 +204,7 @@ private fun DataProgressCard(totalEntries: Int, requiredEntries: Int) {
                     .fillMaxWidth()
                     .height(8.dp)
                     .clip(RoundedCornerShape(4.dp)),
+                drawStopIndicator = {},
             )
             if (remaining > 0) {
                 Spacer(modifier = Modifier.height(4.dp))


### PR DESCRIPTION
## Summary
- Disable M3 `LinearProgressIndicator`'s default stop indicator (`drawStopIndicator = {}`) which rendered a small coloured dot even at 0% progress
- Fixes the graphical defect visible on the discovery screen when diary entries are 0/14

Closes #41

## Test plan
- [ ] Open a profile in discovery mode with 0 diary entries
- [ ] Verify the progress bar is completely empty (no dot visible)
- [ ] Verify progress bar still fills correctly as entries are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)