### PR TITLE
chore: restrict Claude Code action to repo owner only

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,6 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          allowed_users: 'ryan-buttery'
           claude_args: '--allowed-tools Bash(gh)'
 


### PR DESCRIPTION
Add allowed_users to prevent unauthorized users from triggering Claude Code via @claude mentions, protecting against unwanted budget usage.

https://claude.ai/code/session_01RuBdq54wUuMLBAgH1KTUre