### PR TITLE
feat: add EncryptedExportEnvelope model

### DIFF
--- a/app/src/main/java/com/ryan/pollenwitan/data/export/ExportModels.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/export/ExportModels.kt
@@ -114,3 +114,12 @@ data class ExportNotificationPrefs(
     val symptomReminderEnabled: Boolean,
     val symptomReminderHour: Int
 )
+
+@Serializable
+data class EncryptedExportEnvelope(
+    val format: String = "pollenwitan-encrypted-backup",
+    val version: Int = 1,
+    val salt: String,       // Base64-encoded 16-byte PBKDF2 salt
+    val iv: String,         // Base64-encoded 12-byte AES-GCM IV
+    val ciphertext: String  // Base64-encoded AES-256-GCM ciphertext (includes auth tag)
+)


### PR DESCRIPTION
## Summary
- Adds `EncryptedExportEnvelope` data class to `ExportModels.kt` for the encrypted backup on-disk format
- Includes `format` magic string, `version` field, and Base64-encoded `salt`, `iv`, `ciphertext` fields for PBKDF2 + AES-256-GCM encryption

Closes #63

## Test plan
- [x] Verify the model serializes/deserializes correctly with kotlinx.serialization
- [x] Confirm debug build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)