### PR TITLE
fix: prevent DB data loss and trends date range

### DIFF
--- a/app/src/main/java/com/ryan/pollenwitan/data/security/DatabaseEncryption.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/security/DatabaseEncryption.kt
@@ -51,10 +51,11 @@ object DatabaseEncryption {
                     // Verify we can actually open the DB with this passphrase
                     val dbFile = appContext.getDatabasePath(DB_NAME)
                     if (dbFile.exists() && !verifyEncryptedDb(dbFile, passphrase)) {
-                        Log.w(TAG, "Cannot open encrypted DB with current passphrase — deleting for fresh start")
-                        dbFile.delete()
-                        File(dbFile.parent, "$DB_NAME-wal").delete()
-                        File(dbFile.parent, "$DB_NAME-shm").delete()
+                        Log.e(TAG, "Cannot open encrypted DB with current passphrase — falling back to unencrypted")
+                        prefs.edit().putBoolean(KEY_ENCRYPTED, false).apply()
+                        factory = null
+                        initialized = true
+                        return
                     }
                     factory = SupportOpenHelperFactory(passphrase)
                     Log.i(TAG, "Database encryption active")

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/SymptomTrendsViewModel.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/SymptomTrendsViewModel.kt
@@ -87,7 +87,7 @@ class SymptomTrendsViewModel(application: Application) : AndroidViewModel(applic
             )
         } else {
             val endDate = LocalDate.now()
-            val startDate = endDate.minusDays(params.range.days)
+            val startDate = endDate.minusDays(params.range.days - 1)
             val expectedDosesPerDay = SymptomTrendsLogic.expectedDosesPerDay(
                 profile.medicineAssignments
             )


### PR DESCRIPTION
## Summary
- **DB data loss on restart**: `DatabaseEncryption.init()` was deleting the entire Room database when passphrase verification failed (transient I/O error, WAL lock, encoding mismatch). Now falls back to unencrypted mode instead, preserving all dose history and symptom entries.
- **Trends graph missing today**: `SymptomTrendsViewModel` calculated `startDate = endDate.minusDays(rangeDays)` which, combined with `0 until rangeDays`, excluded today from the graph. Fixed to `minusDays(rangeDays - 1)` so the range is inclusive of today.

## Test plan
- [x] Import an unencrypted JSON backup, add medicine doses and symptom diary entries for today
- [x] Verify today's data appears on the symptom trends graph
- [x] Force-stop and reopen the app — confirm all historical data is still present
- [x] Repeat across multiple app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)