### PR TITLE
fix: scope notification PendingIntents to app package

### DIFF
--- a/app/src/main/java/com/ryan/pollenwitan/worker/MissedDoseAlarmReceiver.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/worker/MissedDoseAlarmReceiver.kt
@@ -131,6 +131,7 @@ class MissedDoseAlarmReceiver : BroadcastReceiver() {
             val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
             // Re-create the same PendingIntent (extras don't matter for matching — only requestCode does)
             val intent = Intent(context, MissedDoseAlarmReceiver::class.java).apply {
+                setPackage(context.packageName)
                 action = ACTION_MISSED_DOSE_CHECK
             }
             val reqCode = requestCode(profileIndex, assignmentIndex, slotIndex)
@@ -154,6 +155,7 @@ class MissedDoseAlarmReceiver : BroadcastReceiver() {
             assignmentIndex: Int,
             slotIndex: Int
         ): Intent = Intent(context, MissedDoseAlarmReceiver::class.java).apply {
+            setPackage(context.packageName)
             action = ACTION_MISSED_DOSE_CHECK
             putExtra(EXTRA_PROFILE_ID, profileId)
             putExtra(EXTRA_MEDICINE_ID, medicineId)

--- a/app/src/main/java/com/ryan/pollenwitan/worker/NotificationHelper.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/worker/NotificationHelper.kt
@@ -118,6 +118,7 @@ object NotificationHelper {
 
         if (targetRoute != null) {
             val intent = Intent(context, MainActivity::class.java).apply {
+                setPackage(context.packageName)
                 putExtra(EXTRA_NAVIGATE_TO, targetRoute)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
@@ -162,6 +163,7 @@ object NotificationHelper {
 
         if (targetRoute != null) {
             val intent = Intent(context, MainActivity::class.java).apply {
+                setPackage(context.packageName)
                 putExtra(EXTRA_NAVIGATE_TO, targetRoute)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
@@ -211,6 +213,7 @@ object NotificationHelper {
 
         // "Mark as Taken" action
         val actionIntent = Intent(context, MedicationActionReceiver::class.java).apply {
+            setPackage(context.packageName)
             action = MedicationActionReceiver.ACTION_MARK_DOSE_TAKEN
             putExtra(MedicationActionReceiver.EXTRA_PROFILE_ID, profileId)
             putExtra(MedicationActionReceiver.EXTRA_MEDICINE_ID, medicineId)
@@ -237,6 +240,7 @@ object NotificationHelper {
 
         if (targetRoute != null) {
             val intent = Intent(context, MainActivity::class.java).apply {
+                setPackage(context.packageName)
                 putExtra(EXTRA_NAVIGATE_TO, targetRoute)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }


### PR DESCRIPTION
## Summary
- Adds `setPackage(context.packageName)` to all Intents wrapped in `PendingIntent`s within `NotificationHelper` and `MissedDoseAlarmReceiver`.
- Resolves four CodeQL `java/android/implicit-pendingintents` alerts (#1–#4).

## Background
The wrapped Intents were already constructed with an explicit component class (`Intent(context, MainActivity::class.java)` etc.) and all `PendingIntent`s already used `FLAG_IMMUTABLE`, so this is largely a CodeQL false positive — its Kotlin dataflow does not always recognise the two-arg `Intent` constructor as setting an explicit component. Calling `setPackage(context.packageName)` is the canonical narrow fix the query recognises, and it also serves as a defence-in-depth hardening: only this app's package can ever match the Intent.

## Changes
- `NotificationHelper.kt`: 4 call sites (`sendNotification`, `sendGroupSummary`, `sendMedicationReminder` × 2)
- `MissedDoseAlarmReceiver.kt`: 2 call sites (`cancel()` and `buildIntent()`)

No behavioural change — Intents were already being delivered to the same explicit components.

## Test plan
- [ ] CodeQL re-scan shows alerts #1–#4 resolved
- [ ] Smoke-test notification delivery: morning briefing, threshold alert, medication reminder, missed-dose escalation
- [ ] Tap-through on each notification still navigates to the correct screen
- [ ] "Mark as Taken" action still cancels the missed-dose alarm

🤖 Generated with [Claude Code](https://claude.com/claude-code)