### PR TITLE
feat: rel/1.2.0 wave 1 — dashboard weather, diary notes, pull-to-refr…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,7 @@ val keystoreProperties = Properties().apply {
         load(keystorePropertiesFile.inputStream())
     }
 }
+val hasReleaseKeystore = keystoreProperties.getProperty("storeFile")?.isNotBlank() == true
 
 android {
 namespace = "com.ryan.pollenwitan"
@@ -28,10 +29,12 @@ namespace = "com.ryan.pollenwitan"
 
     signingConfigs {
         create("release") {
-            storeFile = file(keystoreProperties.getProperty("storeFile", ""))
-            storePassword = keystoreProperties.getProperty("storePassword", "")
-            keyAlias = keystoreProperties.getProperty("keyAlias", "")
-            keyPassword = keystoreProperties.getProperty("keyPassword", "")
+            if (hasReleaseKeystore) {
+                storeFile = file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword", "")
+                keyAlias = keystoreProperties.getProperty("keyAlias", "")
+                keyPassword = keystoreProperties.getProperty("keyPassword", "")
+            }
         }
     }
 
@@ -40,7 +43,9 @@ namespace = "com.ryan.pollenwitan"
             isMinifyEnabled = false
             applicationIdSuffix = ".debug"
             resValue("string", "app_name", "PollenWitan (Debug)")
-            signingConfig = signingConfigs.getByName("release")
+            if (hasReleaseKeystore) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
         create("benchmark") {
             initWith(getByName("debug"))
@@ -52,7 +57,9 @@ namespace = "com.ryan.pollenwitan"
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+            if (hasReleaseKeystore) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             isDebuggable = true // Intentional: required for profiling with Android Studio
         }
         release {
@@ -63,7 +70,9 @@ namespace = "com.ryan.pollenwitan"
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+            if (hasReleaseKeystore) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 

--- a/app/src/main/java/com/ryan/pollenwitan/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/local/AppDatabase.kt
@@ -12,7 +12,7 @@ import java.io.File
 
 @Database(
     entities = [CachedForecastEntity::class, DoseHistoryEntity::class, SymptomEntryEntity::class],
-    version = 3,
+    version = 5,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -58,6 +58,27 @@ abstract class AppDatabase : RoomDatabase() {
                     CREATE UNIQUE INDEX IF NOT EXISTS `index_dose_history_profileId_date_medicineId_slotIndex`
                         ON `dose_history` (`profileId`, `date`, `medicineId`, `slotIndex`)
                     """.trimIndent()
+                )
+            }
+        }
+
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Tag existing cached forecasts as the air-quality endpoint so the
+                // new weather-forecast cache rows can coexist on the same table.
+                db.execSQL(
+                    "ALTER TABLE `cached_forecasts` ADD COLUMN `endpoint` TEXT NOT NULL DEFAULT 'air_quality'"
+                )
+            }
+        }
+
+        private val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Optional free-text observation field on diary entries.
+                // Nullable column, no DEFAULT clause so the runtime schema matches
+                // Room's entity-derived schema exactly (no @ColumnInfo defaultValue).
+                db.execSQL(
+                    "ALTER TABLE `symptom_entries` ADD COLUMN `notes` TEXT"
                 )
             }
         }
@@ -152,7 +173,7 @@ abstract class AppDatabase : RoomDatabase() {
                 DB_NAME
             )
                 .setJournalMode(JournalMode.TRUNCATE)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
                 .build()
     }
 }

--- a/app/src/main/java/com/ryan/pollenwitan/data/local/CachedForecastDao.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/local/CachedForecastDao.kt
@@ -10,12 +10,20 @@ interface CachedForecastDao {
     @Query(
         """
         SELECT * FROM cached_forecasts
-        WHERE latitude = :latitude AND longitude = :longitude AND forecastDays = :forecastDays
+        WHERE latitude = :latitude
+          AND longitude = :longitude
+          AND forecastDays = :forecastDays
+          AND endpoint = :endpoint
         ORDER BY fetchedAtMillis DESC
         LIMIT 1
         """
     )
-    suspend fun getLatest(latitude: Double, longitude: Double, forecastDays: Int): CachedForecastEntity?
+    suspend fun getLatest(
+        latitude: Double,
+        longitude: Double,
+        forecastDays: Int,
+        endpoint: String
+    ): CachedForecastEntity?
 
     @Insert
     suspend fun insert(entity: CachedForecastEntity)

--- a/app/src/main/java/com/ryan/pollenwitan/data/local/CachedForecastEntity.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/local/CachedForecastEntity.kt
@@ -1,5 +1,6 @@
 package com.ryan.pollenwitan.data.local
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -10,5 +11,13 @@ data class CachedForecastEntity(
     val longitude: Double,
     val forecastDays: Int,
     val fetchedAtMillis: Long,
-    val responseJson: String
-)
+    val responseJson: String,
+    // defaultValue must match MIGRATION_3_4 so Room's runtime schema check passes
+    @ColumnInfo(defaultValue = ENDPOINT_AIR_QUALITY)
+    val endpoint: String = ENDPOINT_AIR_QUALITY
+) {
+    companion object {
+        const val ENDPOINT_AIR_QUALITY = "air_quality"
+        const val ENDPOINT_WEATHER = "weather"
+    }
+}

--- a/app/src/main/java/com/ryan/pollenwitan/data/local/SymptomEntryEntity.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/local/SymptomEntryEntity.kt
@@ -19,5 +19,6 @@ data class SymptomEntryEntity(
     val peakPollenJson: String,
     val peakAqi: Int,
     val peakPm25: Double,
-    val peakPm10: Double
+    val peakPm10: Double,
+    val notes: String? = null
 )

--- a/app/src/main/java/com/ryan/pollenwitan/data/remote/AirQualityApi.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/remote/AirQualityApi.kt
@@ -40,20 +40,30 @@ class AirQualityApi {
         forecastDays: Int = 1,
         pastDays: Int = 0
     ): String {
-        return executeRequest(latitude, longitude, forecastDays, pastDays).body()
+        return executeRequest(AIR_QUALITY_URL, AIR_QUALITY_HOURLY_PARAMS, latitude, longitude, forecastDays, pastDays).body()
+    }
+
+    suspend fun getWeatherRaw(
+        latitude: Double,
+        longitude: Double,
+        forecastDays: Int = 1
+    ): String {
+        return executeRequest(WEATHER_URL, WEATHER_HOURLY_PARAMS, latitude, longitude, forecastDays).body()
     }
 
     private suspend fun executeRequest(
+        url: String,
+        hourlyParams: String,
         latitude: Double,
         longitude: Double,
         forecastDays: Int,
         pastDays: Int = 0
     ): HttpResponse {
         return retryWithBackoff {
-            client.get(BASE_URL) {
+            client.get(url) {
                 parameter("latitude", latitude)
                 parameter("longitude", longitude)
-                parameter("hourly", HOURLY_PARAMS)
+                parameter("hourly", hourlyParams)
                 parameter("timezone", java.time.ZoneId.systemDefault().id)
                 parameter("forecast_days", forecastDays)
                 if (pastDays > 0) parameter("past_days", pastDays)
@@ -113,8 +123,11 @@ class AirQualityApi {
     }
 
     companion object {
-        private const val BASE_URL = "https://air-quality-api.open-meteo.com/v1/air-quality"
-        private const val HOURLY_PARAMS = "birch_pollen,alder_pollen,grass_pollen,mugwort_pollen,ragweed_pollen,olive_pollen,pm2_5,pm10,european_aqi"
+        private const val AIR_QUALITY_URL = "https://air-quality-api.open-meteo.com/v1/air-quality"
+        private const val AIR_QUALITY_HOURLY_PARAMS = "birch_pollen,alder_pollen,grass_pollen,mugwort_pollen,ragweed_pollen,olive_pollen,pm2_5,pm10,european_aqi"
+
+        private const val WEATHER_URL = "https://api.open-meteo.com/v1/forecast"
+        private const val WEATHER_HOURLY_PARAMS = "wind_speed_10m,wind_direction_10m,precipitation_probability"
 
         private const val CONNECT_TIMEOUT_MS = 15_000L
         private const val REQUEST_TIMEOUT_MS = 30_000L

--- a/app/src/main/java/com/ryan/pollenwitan/data/remote/dto/WeatherForecastResponse.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/remote/dto/WeatherForecastResponse.kt
@@ -1,0 +1,19 @@
+package com.ryan.pollenwitan.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeatherForecastResponse(
+    val latitude: Double,
+    val longitude: Double,
+    val hourly: WeatherHourlyData
+)
+
+@Serializable
+data class WeatherHourlyData(
+    val time: List<String>,
+    @SerialName("wind_speed_10m") val windSpeed10m: List<Double?>? = null,
+    @SerialName("wind_direction_10m") val windDirection10m: List<Double?>? = null,
+    @SerialName("precipitation_probability") val precipitationProbability: List<Int?>? = null
+)

--- a/app/src/main/java/com/ryan/pollenwitan/data/repository/AirQualityRepository.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/repository/AirQualityRepository.kt
@@ -1,11 +1,14 @@
 package com.ryan.pollenwitan.data.repository
 
 import android.content.Context
+import android.util.Log
 import com.ryan.pollenwitan.data.local.AppDatabase
 import com.ryan.pollenwitan.data.local.CachedForecastEntity
 import com.ryan.pollenwitan.data.remote.AirQualityApi
 import com.ryan.pollenwitan.data.remote.dto.AirQualityResponse
 import com.ryan.pollenwitan.data.remote.dto.HourlyData
+import com.ryan.pollenwitan.data.remote.dto.WeatherForecastResponse
+import com.ryan.pollenwitan.data.remote.dto.WeatherHourlyData
 import com.ryan.pollenwitan.domain.model.CurrentConditions
 import com.ryan.pollenwitan.domain.model.DayPeriod
 import com.ryan.pollenwitan.domain.model.ForecastDay
@@ -15,6 +18,9 @@ import com.ryan.pollenwitan.domain.model.PeriodSummary
 import com.ryan.pollenwitan.domain.model.PollenReading
 import com.ryan.pollenwitan.domain.model.PollenType
 import com.ryan.pollenwitan.domain.model.SeverityClassifier
+import com.ryan.pollenwitan.domain.model.WeatherConditions
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -32,38 +38,56 @@ class AirQualityRepository(context: Context) {
         latitude: Double,
         longitude: Double
     ): Result<CurrentConditions> = runCatching {
-        val now = LocalDateTime.now().truncatedTo(ChronoUnit.HOURS)
+        coroutineScope {
+            val now = LocalDateTime.now().truncatedTo(ChronoUnit.HOURS)
 
-        fun findIndex(hourly: HourlyData) = hourly.time.indexOfFirst { timeStr ->
-            LocalDateTime.parse(timeStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME) == now
+            fun findIndex(hourly: HourlyData) = hourly.time.indexOfFirst { timeStr ->
+                LocalDateTime.parse(timeStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME) == now
+            }
+
+            // Run the air-quality fetch (required) and the weather fetch (best-effort)
+            // in parallel. Weather failures degrade gracefully to a null context row.
+            val airQualityDeferred = async {
+                fetchOrCache(latitude, longitude, forecastDays = 1)
+            }
+            val weatherDeferred = async {
+                runCatching { fetchWeatherOrCache(latitude, longitude, forecastDays = 1) }
+                    .onFailure { Log.w(TAG, "Weather fetch failed; falling back to null", it) }
+                    .getOrNull()
+            }
+
+            var (response, fetchedAt) = airQualityDeferred.await()
+            var index = findIndex(response.hourly)
+
+            if (index == -1) {
+                // Cached data doesn't cover the current hour (e.g. day boundary crossed); force a live fetch
+                val fresh = fetchOrCache(latitude, longitude, forecastDays = 1, forceRefresh = true)
+                response = fresh.first
+                fetchedAt = fresh.second
+                index = findIndex(response.hourly)
+            }
+
+            if (index == -1) error("Current hour not found in API response")
+
+            val hourly = response.hourly
+            val readings = parseReadingsAtIndex(hourly, index)
+            val aqiValue = hourly.europeanAqi?.getOrNull(index) ?: 0
+
+            val weather = weatherDeferred.await()?.let { weatherResponse ->
+                weatherConditionsAt(weatherResponse.hourly, now)
+            }
+
+            CurrentConditions(
+                pollenReadings = readings,
+                europeanAqi = aqiValue,
+                pm25 = hourly.pm25?.getOrNull(index) ?: 0.0,
+                pm10 = hourly.pm10?.getOrNull(index) ?: 0.0,
+                aqiSeverity = SeverityClassifier.aqiSeverity(aqiValue),
+                timestamp = now,
+                fetchedAtMillis = fetchedAt,
+                weather = weather
+            )
         }
-
-        var (response, fetchedAt) = fetchOrCache(latitude, longitude, forecastDays = 1)
-        var index = findIndex(response.hourly)
-
-        if (index == -1) {
-            // Cached data doesn't cover the current hour (e.g. day boundary crossed); force a live fetch
-            val fresh = fetchOrCache(latitude, longitude, forecastDays = 1, forceRefresh = true)
-            response = fresh.first
-            fetchedAt = fresh.second
-            index = findIndex(response.hourly)
-        }
-
-        if (index == -1) error("Current hour not found in API response")
-
-        val hourly = response.hourly
-        val readings = parseReadingsAtIndex(hourly, index)
-        val aqiValue = hourly.europeanAqi?.getOrNull(index) ?: 0
-
-        CurrentConditions(
-            pollenReadings = readings,
-            europeanAqi = aqiValue,
-            pm25 = hourly.pm25?.getOrNull(index) ?: 0.0,
-            pm10 = hourly.pm10?.getOrNull(index) ?: 0.0,
-            aqiSeverity = SeverityClassifier.aqiSeverity(aqiValue),
-            timestamp = now,
-            fetchedAtMillis = fetchedAt
-        )
     }
 
     suspend fun getForecast(
@@ -113,7 +137,9 @@ class AirQualityRepository(context: Context) {
         val now = System.currentTimeMillis()
 
         if (!forceRefresh) {
-            val cached = dao.getLatest(roundedLat, roundedLon, forecastDays)
+            val cached = dao.getLatest(
+                roundedLat, roundedLon, forecastDays, CachedForecastEntity.ENDPOINT_AIR_QUALITY
+            )
             if (cached != null && (now - cached.fetchedAtMillis) < CACHE_MAX_AGE_MS) {
                 return json.decodeFromString<AirQualityResponse>(cached.responseJson) to cached.fetchedAtMillis
             }
@@ -128,7 +154,8 @@ class AirQualityRepository(context: Context) {
                 longitude = roundedLon,
                 forecastDays = forecastDays,
                 fetchedAtMillis = now,
-                responseJson = rawJson
+                responseJson = rawJson,
+                endpoint = CachedForecastEntity.ENDPOINT_AIR_QUALITY
             )
         )
 
@@ -137,12 +164,74 @@ class AirQualityRepository(context: Context) {
         return response to now
     }
 
+    private suspend fun fetchWeatherOrCache(
+        latitude: Double,
+        longitude: Double,
+        forecastDays: Int
+    ): WeatherForecastResponse {
+        val roundedLat = roundCoord(latitude)
+        val roundedLon = roundCoord(longitude)
+        val now = System.currentTimeMillis()
+
+        val cached = dao.getLatest(
+            roundedLat, roundedLon, forecastDays, CachedForecastEntity.ENDPOINT_WEATHER
+        )
+        if (cached != null && (now - cached.fetchedAtMillis) < CACHE_MAX_AGE_MS) {
+            return json.decodeFromString<WeatherForecastResponse>(cached.responseJson)
+        }
+
+        val rawJson = api.getWeatherRaw(latitude, longitude, forecastDays)
+        val response = json.decodeFromString<WeatherForecastResponse>(rawJson)
+
+        dao.insert(
+            CachedForecastEntity(
+                latitude = roundedLat,
+                longitude = roundedLon,
+                forecastDays = forecastDays,
+                fetchedAtMillis = now,
+                responseJson = rawJson,
+                endpoint = CachedForecastEntity.ENDPOINT_WEATHER
+            )
+        )
+
+        return response
+    }
+
     companion object {
+        private const val TAG = "AirQualityRepository"
         internal const val CACHE_MAX_AGE_MS = 60 * 60 * 1000L
         internal const val CACHE_CLEANUP_AGE_MS = 24 * 60 * 60 * 1000L
 
         internal fun roundCoord(value: Double): Double =
             (value * 100).roundToInt() / 100.0
+
+        /**
+         * Resolve the wind/precipitation values that line up with [target] in the
+         * weather forecast response. Falls back to null if the matching hour is
+         * missing or all three fields are absent for that index.
+         */
+        internal fun weatherConditionsAt(
+            hourly: WeatherHourlyData,
+            target: LocalDateTime
+        ): WeatherConditions? {
+            val index = hourly.time.indexOfFirst { timeStr ->
+                LocalDateTime.parse(timeStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME) == target
+            }
+            if (index == -1) return null
+
+            val windSpeed = hourly.windSpeed10m?.getOrNull(index)
+            val windDir = hourly.windDirection10m?.getOrNull(index)
+            val precipProb = hourly.precipitationProbability?.getOrNull(index)
+
+            // If every field is null the row carries no useful info; degrade to null.
+            if (windSpeed == null && windDir == null && precipProb == null) return null
+
+            return WeatherConditions(
+                windSpeedKmh = windSpeed ?: 0.0,
+                windDirectionDegrees = windDir?.toInt()?.mod(360) ?: 0,
+                precipitationProbabilityPercent = precipProb ?: 0
+            )
+        }
 
         internal fun parseReadingsAtIndex(hourly: HourlyData, index: Int): List<PollenReading> {
             val birchValue = hourly.birchPollen?.getOrNull(index) ?: 0.0

--- a/app/src/main/java/com/ryan/pollenwitan/data/repository/SymptomDiaryRepository.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/data/repository/SymptomDiaryRepository.kt
@@ -62,7 +62,8 @@ class SymptomDiaryRepository(private val context: Context) {
             peakPollenJson = entry.peakPollenJson,
             peakAqi = entry.peakAqi,
             peakPm25 = entry.peakPm25,
-            peakPm10 = entry.peakPm10
+            peakPm10 = entry.peakPm10,
+            notes = entry.notes?.takeIf { it.isNotBlank() }
         )
     }
 
@@ -81,7 +82,8 @@ class SymptomDiaryRepository(private val context: Context) {
             peakPollenJson = entity.peakPollenJson,
             peakAqi = entity.peakAqi,
             peakPm25 = entity.peakPm25,
-            peakPm10 = entity.peakPm10
+            peakPm10 = entity.peakPm10,
+            notes = entity.notes
         )
     }
 }

--- a/app/src/main/java/com/ryan/pollenwitan/domain/model/AirQualityData.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/domain/model/AirQualityData.kt
@@ -15,5 +15,20 @@ data class CurrentConditions(
     val pm10: Double,
     val aqiSeverity: SeverityLevel,
     val timestamp: LocalDateTime,
-    val fetchedAtMillis: Long = System.currentTimeMillis()
+    val fetchedAtMillis: Long = System.currentTimeMillis(),
+    val weather: WeatherConditions? = null
+)
+
+/**
+ * Meteorological context for the current hour, sourced from the Open-Meteo
+ * forecast endpoint. Nullable on [CurrentConditions] so the dashboard degrades
+ * gracefully if the secondary fetch fails.
+ */
+data class WeatherConditions(
+    /** km/h */
+    val windSpeedKmh: Double,
+    /** Compass bearing in degrees (0 = N, 90 = E, 180 = S, 270 = W). */
+    val windDirectionDegrees: Int,
+    /** Probability of precipitation, 0-100. */
+    val precipitationProbabilityPercent: Int
 )

--- a/app/src/main/java/com/ryan/pollenwitan/domain/model/SymptomEntry.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/domain/model/SymptomEntry.kt
@@ -16,5 +16,10 @@ data class SymptomDiaryEntry(
     val peakPollenJson: String,
     val peakAqi: Int,
     val peakPm25: Double,
-    val peakPm10: Double
+    val peakPm10: Double,
+    /**
+     * Optional free-text observation for the day, intended for future PDF export
+     * to medical providers. Null when the user didn't add a note.
+     */
+    val notes: String? = null
 )

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/DashboardScreen.kt
@@ -15,13 +15,21 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Air
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.snap
@@ -51,6 +59,7 @@ import com.ryan.pollenwitan.domain.model.PollenReading
 import com.ryan.pollenwitan.domain.model.SeverityClassifier
 import com.ryan.pollenwitan.domain.model.SymptomDiaryEntry
 import com.ryan.pollenwitan.domain.model.UserProfile
+import com.ryan.pollenwitan.domain.model.WeatherConditions
 import com.ryan.pollenwitan.ui.components.ProfileSwitcher
 import com.ryan.pollenwitan.ui.components.StaleDataBanner
 import com.ryan.pollenwitan.ui.theme.localizedName
@@ -62,6 +71,7 @@ import java.time.LocalTime
 import androidx.lifecycle.viewmodel.compose.viewModel
 import java.time.format.DateTimeFormatter
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DashboardScreen(
     viewModel: DashboardViewModel = viewModel(),
@@ -72,21 +82,27 @@ fun DashboardScreen(
 
     when (val weather = uiState.weatherState) {
         is WeatherState.Loading -> LoadingContent()
-        is WeatherState.Success -> DashboardContent(
-            conditions = weather.conditions,
-            fetchedAtMillis = weather.fetchedAtMillis,
-            profiles = uiState.profiles,
-            selectedProfile = uiState.selectedProfile,
-            locationDisplayName = uiState.locationDisplayName,
-            medicineSlots = uiState.medicineSlots,
-            todaySymptomEntry = uiState.todaySymptomEntry,
-            onSelectProfile = viewModel::selectProfile,
+        is WeatherState.Success -> PullToRefreshBox(
+            isRefreshing = uiState.isRefreshing,
             onRefresh = viewModel::refresh,
-            onConfirmDose = viewModel::confirmDose,
-            onUnconfirmDose = viewModel::unconfirmDose,
-            onNavigateToCheckIn = onNavigateToCheckIn,
-            onNavigateToDiscovery = onNavigateToDiscovery
-        )
+            modifier = Modifier.fillMaxSize()
+        ) {
+            DashboardContent(
+                conditions = weather.conditions,
+                fetchedAtMillis = weather.fetchedAtMillis,
+                profiles = uiState.profiles,
+                selectedProfile = uiState.selectedProfile,
+                locationDisplayName = uiState.locationDisplayName,
+                medicineSlots = uiState.medicineSlots,
+                todaySymptomEntry = uiState.todaySymptomEntry,
+                onSelectProfile = viewModel::selectProfile,
+                onRefresh = viewModel::refresh,
+                onConfirmDose = viewModel::confirmDose,
+                onUnconfirmDose = viewModel::unconfirmDose,
+                onNavigateToCheckIn = onNavigateToCheckIn,
+                onNavigateToDiscovery = onNavigateToDiscovery
+            )
+        }
         is WeatherState.Error -> ErrorContent(
             message = weather.message,
             onRetry = viewModel::refresh
@@ -151,12 +167,30 @@ private fun DashboardContent(
             .verticalScroll(rememberScrollState())
             .padding(16.dp)
     ) {
-        // Header
-        Text(
-            text = selectedProfile?.displayName ?: locationDisplayName.ifEmpty { stringResource(R.string.common_loading) },
-            style = MaterialTheme.typography.headlineMedium,
-            fontWeight = FontWeight.Bold
-        )
+        // Header — title plus a small refresh affordance for users who don't
+        // know about the pull-to-refresh gesture.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = selectedProfile?.displayName ?: locationDisplayName.ifEmpty { stringResource(R.string.common_loading) },
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(
+                onClick = onRefresh,
+                modifier = Modifier.size(36.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Refresh,
+                    contentDescription = stringResource(R.string.common_refresh),
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
         if (selectedProfile != null && locationDisplayName.isNotEmpty()) {
             Text(
                 text = locationDisplayName,
@@ -257,6 +291,12 @@ private fun DashboardContent(
                     }
                 }
             }
+        }
+
+        // Weather context — wind and rain probability for the current hour
+        conditions.weather?.let { weather ->
+            Spacer(modifier = Modifier.height(12.dp))
+            WeatherContextCard(weather)
         }
 
         // Discovery mode banner
@@ -501,14 +541,6 @@ private fun DashboardContent(
         }
 
         Spacer(modifier = Modifier.height(24.dp))
-
-        // Refresh button
-        Button(
-            onClick = onRefresh,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
-        ) {
-            Text(stringResource(R.string.common_refresh))
-        }
     }
 }
 
@@ -571,4 +603,82 @@ private fun PollenRow(reading: PollenReading, dimmed: Boolean = false) {
 @Composable
 private fun Context.isReduceMotionEnabled(): Boolean = remember {
     Settings.Global.getFloat(contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) == 0f
+}
+
+@Composable
+private fun WeatherContextCard(weather: WeatherConditions) {
+    val windKmh = weather.windSpeedKmh.toInt()
+    val compass = compassDirection(weather.windDirectionDegrees)
+    val rainPct = weather.precipitationProbabilityPercent
+    val cd = stringResource(
+        R.string.dashboard_weather_content_description,
+        windKmh, compass, rainPct
+    )
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = cd },
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            WeatherStat(
+                icon = Icons.Filled.Air,
+                label = stringResource(R.string.dashboard_weather_wind_label),
+                value = stringResource(R.string.dashboard_weather_wind_value, windKmh, compass)
+            )
+            WeatherStat(
+                icon = Icons.Filled.WaterDrop,
+                label = stringResource(R.string.dashboard_weather_rain_label),
+                value = stringResource(R.string.dashboard_weather_rain_value, rainPct)
+            )
+        }
+    }
+}
+
+@Composable
+private fun WeatherStat(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    value: String
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Column {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
+}
+
+/**
+ * Convert a wind-direction bearing (0–360°) to an 8-point compass abbreviation.
+ * 0° / 360° = N, 90° = E, 180° = S, 270° = W.
+ */
+private fun compassDirection(degrees: Int): String {
+    val normalized = ((degrees % 360) + 360) % 360
+    val sectors = arrayOf("N", "NE", "E", "SE", "S", "SW", "W", "NW")
+    val index = ((normalized + 22) / 45) % 8
+    return sectors[index]
 }

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/DashboardViewModel.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/DashboardViewModel.kt
@@ -48,7 +48,13 @@ data class DashboardUiState(
     val selectedProfileId: String = "",
     val locationDisplayName: String = "",
     val medicineSlots: List<MedicineSlot> = emptyList(),
-    val todaySymptomEntry: SymptomDiaryEntry? = null
+    val todaySymptomEntry: SymptomDiaryEntry? = null,
+    /**
+     * True while a pull-to-refresh / manual refresh is in flight on top of
+     * existing data. The full Loading screen is only shown for the initial
+     * load (when [weatherState] is [WeatherState.Loading]).
+     */
+    val isRefreshing: Boolean = false
 ) {
     val selectedProfile: UserProfile?
         get() = profiles.find { it.id == selectedProfileId }
@@ -66,15 +72,16 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
     private val symptomDiaryRepository = SymptomDiaryRepository(application)
 
     private val _weatherState = MutableStateFlow<WeatherState>(WeatherState.Loading)
+    private val _isRefreshing = MutableStateFlow(false)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val uiState: StateFlow<DashboardUiState> = combine(
-        _weatherState,
+        combine(_weatherState, _isRefreshing) { weather, refreshing -> weather to refreshing },
         profileRepository.getProfiles(),
         profileRepository.getSelectedProfileId(),
         locationRepository.getLocation(),
         medicineRepository.getMedicines()
-    ) { weather, profiles, selectedId, globalLocation, medicines ->
+    ) { (weather, isRefreshing), profiles, selectedId, globalLocation, medicines ->
         val selectedProfile = profiles.find { it.id == selectedId }
         val effectiveLocation = ProfileRepository.resolveLocation(selectedProfile, globalLocation)
         Triple(
@@ -82,7 +89,8 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
                 weatherState = weather,
                 profiles = profiles,
                 selectedProfileId = selectedId,
-                locationDisplayName = effectiveLocation.displayName
+                locationDisplayName = effectiveLocation.displayName,
+                isRefreshing = isRefreshing
             ),
             selectedProfile,
             medicines
@@ -137,19 +145,38 @@ class DashboardViewModel(application: Application) : AndroidViewModel(applicatio
 
     fun refresh() {
         viewModelScope.launch {
-            _weatherState.value = WeatherState.Loading
-            val globalLocation = locationRepository.getLocation().first()
-            val profiles = profileRepository.getProfiles().first()
-            val selectedId = profileRepository.getSelectedProfileId().first()
-            val selectedProfile = profiles.find { it.id == selectedId }
-            val location = ProfileRepository.resolveLocation(selectedProfile, globalLocation)
-            airQualityRepository.getCurrentConditions(
-                location.latitude,
-                location.longitude
-            ).fold(
-                onSuccess = { _weatherState.value = WeatherState.Success(it, it.fetchedAtMillis) },
-                onFailure = { _weatherState.value = WeatherState.Error(it.message ?: "Unknown error") }
-            )
+            // If we already have data, run the refresh in the background and keep
+            // existing content visible. If this is the first load (or a previous
+            // load errored), fall back to the full Loading screen.
+            val hasData = _weatherState.value is WeatherState.Success
+            if (hasData) {
+                _isRefreshing.value = true
+            } else {
+                _weatherState.value = WeatherState.Loading
+            }
+
+            try {
+                val globalLocation = locationRepository.getLocation().first()
+                val profiles = profileRepository.getProfiles().first()
+                val selectedId = profileRepository.getSelectedProfileId().first()
+                val selectedProfile = profiles.find { it.id == selectedId }
+                val location = ProfileRepository.resolveLocation(selectedProfile, globalLocation)
+                airQualityRepository.getCurrentConditions(
+                    location.latitude,
+                    location.longitude
+                ).fold(
+                    onSuccess = { _weatherState.value = WeatherState.Success(it, it.fetchedAtMillis) },
+                    onFailure = {
+                        // Only blow away existing content if there was none to begin with;
+                        // background refresh failures leave the dashboard intact.
+                        if (!hasData) {
+                            _weatherState.value = WeatherState.Error(it.message ?: "Unknown error")
+                        }
+                    }
+                )
+            } finally {
+                _isRefreshing.value = false
+            }
         }
     }
 

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/ProfileEditLogic.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/ProfileEditLogic.kt
@@ -29,7 +29,9 @@ internal object ProfileEditLogic {
         InvalidLatitude,
         InvalidLongitude,
         InvalidThreshold,
-        InvalidDose
+        InvalidDose,
+        TooManyReminderHours,
+        InvalidReminderHour
     }
 
     fun validate(state: ProfileEditUiState): ValidationResult {
@@ -60,6 +62,12 @@ internal object ProfileEditLogic {
             val times = assignment.timesPerDay.toIntOrNull()
             if (dose == null || dose !in 1..MAX_DOSE || times == null || times !in 1..MAX_TIMES_PER_DAY) {
                 return ValidationResult.Invalid(ValidationReason.InvalidDose)
+            }
+            if (assignment.reminderHours.any { it !in 0..23 }) {
+                return ValidationResult.Invalid(ValidationReason.InvalidReminderHour)
+            }
+            if (assignment.reminderHours.size > times) {
+                return ValidationResult.Invalid(ValidationReason.TooManyReminderHours)
             }
         }
         return ValidationResult.Valid

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/ProfileEditScreen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/ProfileEditScreen.kt
@@ -651,14 +651,29 @@ private fun MedicineAssignmentCard(
 
             Spacer(modifier = Modifier.height(12.dp))
             Text(stringResource(R.string.profile_reminder_hours), style = MaterialTheme.typography.bodyMedium)
+            val timesPerDayInt = assignment.timesPerDay.toIntOrNull()
+            val limitReached = timesPerDayInt != null &&
+                assignment.reminderHours.size >= timesPerDayInt
+            Text(
+                text = stringResource(
+                    R.string.profile_reminder_hours_hint,
+                    assignment.reminderHours.size,
+                    timesPerDayInt ?: 0
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = if (limitReached) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant
+            )
             Spacer(modifier = Modifier.height(4.dp))
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                (6..22).forEach { hour ->
+                (0..23).forEach { hour ->
+                    val isSelected = hour in assignment.reminderHours
                     FilterChip(
-                        selected = hour in assignment.reminderHours,
+                        selected = isSelected,
+                        enabled = isSelected || !limitReached,
                         onClick = { onToggleHour(hour) },
                         label = { Text(String.format("%02d", hour)) }
                     )

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/ProfileEditViewModel.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/ProfileEditViewModel.kt
@@ -232,13 +232,34 @@ class ProfileEditViewModel(application: Application) : AndroidViewModel(applicat
     }
 
     fun updateAssignmentTimesPerDay(medicineId: String, times: String) {
-        updateAssignment(medicineId) { it.copy(timesPerDay = times) }
+        updateAssignment(medicineId) { assignment ->
+            // If the new value is a valid int smaller than the current
+            // reminder hour count, trim the trailing hours so validation
+            // doesn't immediately fail. Earlier hours are kept.
+            val newLimit = times.toIntOrNull()
+            val trimmed = if (newLimit != null && newLimit in 1..ProfileEditLogic.MAX_TIMES_PER_DAY &&
+                assignment.reminderHours.size > newLimit
+            ) {
+                assignment.reminderHours.take(newLimit)
+            } else {
+                assignment.reminderHours
+            }
+            assignment.copy(timesPerDay = times, reminderHours = trimmed)
+        }
     }
 
     fun toggleReminderHour(medicineId: String, hour: Int) {
         updateAssignment(medicineId) { assignment ->
             val hours = assignment.reminderHours.toMutableList()
-            if (hour in hours) hours.remove(hour) else hours.add(hour)
+            if (hour in hours) {
+                hours.remove(hour)
+            } else {
+                // Cap selection at the configured times-per-day to prevent
+                // selecting more reminder hours than doses.
+                val limit = assignment.timesPerDay.toIntOrNull() ?: ProfileEditLogic.MAX_TIMES_PER_DAY
+                if (hours.size >= limit) return@updateAssignment assignment
+                hours.add(hour)
+            }
             assignment.copy(reminderHours = hours.sorted())
         }
     }

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/SymptomCheckInScreen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/SymptomCheckInScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -120,6 +121,18 @@ fun SymptomCheckInScreen(
             )
             Spacer(modifier = Modifier.height(16.dp))
         }
+
+        // Free-text observation for the day. Optional; intended for future PDF
+        // export to medical providers.
+        OutlinedTextField(
+            value = uiState.notes,
+            onValueChange = viewModel::setNotes,
+            label = { Text(stringResource(R.string.symptom_checkin_notes_label)) },
+            placeholder = { Text(stringResource(R.string.symptom_checkin_notes_placeholder)) },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 3,
+            maxLines = 6
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/SymptomCheckInViewModel.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/SymptomCheckInViewModel.kt
@@ -24,6 +24,7 @@ import java.time.LocalDate
 data class SymptomCheckInUiState(
     val trackedSymptoms: List<TrackedSymptom> = emptyList(),
     val ratings: Map<String, Int> = emptyMap(),
+    val notes: String = "",
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
     val savedSuccessfully: Boolean = false,
@@ -73,6 +74,7 @@ class SymptomCheckInViewModel(application: Application) : AndroidViewModel(appli
             _uiState.value = SymptomCheckInUiState(
                 trackedSymptoms = symptoms,
                 ratings = ratings,
+                notes = existing?.notes.orEmpty(),
                 isLoading = false,
                 profileName = profile.displayName,
                 targetDate = targetDate,
@@ -86,6 +88,10 @@ class SymptomCheckInViewModel(application: Application) : AndroidViewModel(appli
         _uiState.value = current.copy(
             ratings = current.ratings + (symptomId to severity)
         )
+    }
+
+    fun setNotes(value: String) {
+        _uiState.value = _uiState.value.copy(notes = value)
     }
 
     fun save() {
@@ -152,7 +158,8 @@ class SymptomCheckInViewModel(application: Application) : AndroidViewModel(appli
                 peakPollenJson = peakPollenJson,
                 peakAqi = peakAqi,
                 peakPm25 = peakPm25,
-                peakPm10 = peakPm10
+                peakPm10 = peakPm10,
+                notes = state.notes.trim().takeIf { it.isNotEmpty() }
             )
 
             symptomDiaryRepository.logEntry(entry)

--- a/app/src/main/java/com/ryan/pollenwitan/ui/screens/SymptomDiaryScreen.kt
+++ b/app/src/main/java/com/ryan/pollenwitan/ui/screens/SymptomDiaryScreen.kt
@@ -298,6 +298,21 @@ private fun DiaryEntryCard(
                 }
             }
 
+            // Free-text note (if logged)
+            entry.notes?.takeIf { it.isNotBlank() }?.let { note ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.symptom_diary_notes_heading),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = note,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+
             // Environmental snapshot
             if (entry.peakAqi > 0) {
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,12 @@
     <string name="dashboard_no_tracked_allergens">No tracked allergens</string>
     <string name="dashboard_air_quality">Air Quality</string>
     <string name="dashboard_european_aqi">European AQI</string>
+    <string name="dashboard_weather_context">Weather</string>
+    <string name="dashboard_weather_wind_label">Wind</string>
+    <string name="dashboard_weather_wind_value">%1$d km/h %2$s</string>
+    <string name="dashboard_weather_rain_label">Rain</string>
+    <string name="dashboard_weather_rain_value">%1$d%%</string>
+    <string name="dashboard_weather_content_description">Wind %1$d km/h from %2$s, %3$d%% rain probability</string>
     <string name="dashboard_medicines">Medicines</string>
     <string name="dashboard_dose_format">%1$d %2$s</string>
 
@@ -202,6 +208,7 @@
     <string name="profile_dose">Dose</string>
     <string name="profile_times_per_day">Times/day</string>
     <string name="profile_reminder_hours">Reminder hours</string>
+    <string name="profile_reminder_hours_hint">%1$d of %2$d selected</string>
     <string name="profile_add_medicine">Add Medicine</string>
 
     <!-- Profile list -->
@@ -325,6 +332,9 @@
     <string name="symptom_checkin_prompt_early">Check back this evening to log today\u2019s symptoms.</string>
     <string name="symptom_checkin_button_evening">Log Evening Check-In</string>
     <string name="symptom_checkin_button_update">Update Check-In</string>
+    <string name="symptom_checkin_notes_label">Notes (optional)</string>
+    <string name="symptom_checkin_notes_placeholder">Anything else worth noting today? (e.g. felt worse after gardening)</string>
+    <string name="symptom_diary_notes_heading">Notes</string>
     <string name="symptom_avg_severity">Avg severity: %1$.1f</string>
     <string name="nav_symptom_diary">Symptom Diary</string>
     <string name="symptom_diary_title">Symptom Diary</string>

--- a/app/src/test/java/com/ryan/pollenwitan/data/repository/AirQualityRepositoryTest.kt
+++ b/app/src/test/java/com/ryan/pollenwitan/data/repository/AirQualityRepositoryTest.kt
@@ -1,10 +1,12 @@
 package com.ryan.pollenwitan.data.repository
 
 import com.ryan.pollenwitan.data.remote.dto.HourlyData
+import com.ryan.pollenwitan.data.remote.dto.WeatherHourlyData
 import com.ryan.pollenwitan.data.repository.AirQualityRepository.Companion.buildForecastDays
 import com.ryan.pollenwitan.data.repository.AirQualityRepository.Companion.parseReadingsAtIndex
 import com.ryan.pollenwitan.data.repository.AirQualityRepository.Companion.peakPollenReadings
 import com.ryan.pollenwitan.data.repository.AirQualityRepository.Companion.roundCoord
+import com.ryan.pollenwitan.data.repository.AirQualityRepository.Companion.weatherConditionsAt
 import com.ryan.pollenwitan.data.repository.AirQualityRepository.Companion.CACHE_MAX_AGE_MS
 import com.ryan.pollenwitan.data.repository.AirQualityRepository.Companion.CACHE_CLEANUP_AGE_MS
 import com.ryan.pollenwitan.domain.model.DayPeriod
@@ -14,6 +16,8 @@ import com.ryan.pollenwitan.domain.model.PollenType
 import com.ryan.pollenwitan.domain.model.SeverityClassifier
 import com.ryan.pollenwitan.domain.model.SeverityLevel
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.LocalDate
@@ -441,6 +445,89 @@ class AirQualityRepositoryTest {
         assertEquals(2, days[0].hourlyReadings.size)
         assertEquals(LocalDateTime.of(2026, 3, 28, 10, 0), days[0].hourlyReadings[0].hour)
         assertEquals(LocalDateTime.of(2026, 3, 28, 14, 0), days[0].hourlyReadings[1].hour)
+    }
+
+    // ── weatherConditionsAt ─────────────────────────────────────────────
+
+    @Test
+    fun `weatherConditionsAt picks the matching hour`() {
+        val target = LocalDateTime.of(2026, 4, 9, 14, 0)
+        val hourly = WeatherHourlyData(
+            time = listOf(
+                "2026-04-09T13:00",
+                "2026-04-09T14:00",
+                "2026-04-09T15:00"
+            ),
+            windSpeed10m = listOf(5.0, 12.5, 20.0),
+            windDirection10m = listOf(45.0, 180.0, 270.0),
+            precipitationProbability = listOf(0, 60, 90)
+        )
+
+        val result = weatherConditionsAt(hourly, target)
+
+        assertNotNull(result)
+        assertEquals(12.5, result!!.windSpeedKmh, 0.001)
+        assertEquals(180, result.windDirectionDegrees)
+        assertEquals(60, result.precipitationProbabilityPercent)
+    }
+
+    @Test
+    fun `weatherConditionsAt returns null when target hour absent`() {
+        val target = LocalDateTime.of(2026, 4, 9, 14, 0)
+        val hourly = WeatherHourlyData(
+            time = listOf("2026-04-09T13:00", "2026-04-09T15:00"),
+            windSpeed10m = listOf(5.0, 20.0),
+            windDirection10m = listOf(45.0, 270.0),
+            precipitationProbability = listOf(10, 90)
+        )
+
+        assertNull(weatherConditionsAt(hourly, target))
+    }
+
+    @Test
+    fun `weatherConditionsAt returns null when all fields null at index`() {
+        val target = LocalDateTime.of(2026, 4, 9, 14, 0)
+        val hourly = WeatherHourlyData(
+            time = listOf("2026-04-09T14:00"),
+            windSpeed10m = listOf(null),
+            windDirection10m = listOf(null),
+            precipitationProbability = listOf(null)
+        )
+
+        assertNull(weatherConditionsAt(hourly, target))
+    }
+
+    @Test
+    fun `weatherConditionsAt fills missing fields with zero when at least one present`() {
+        val target = LocalDateTime.of(2026, 4, 9, 14, 0)
+        val hourly = WeatherHourlyData(
+            time = listOf("2026-04-09T14:00"),
+            windSpeed10m = listOf(null),
+            windDirection10m = listOf(null),
+            precipitationProbability = listOf(75)
+        )
+
+        val result = weatherConditionsAt(hourly, target)
+
+        assertNotNull(result)
+        assertEquals(0.0, result!!.windSpeedKmh, 0.001)
+        assertEquals(0, result.windDirectionDegrees)
+        assertEquals(75, result.precipitationProbabilityPercent)
+    }
+
+    @Test
+    fun `weatherConditionsAt normalises wind direction modulo 360`() {
+        val target = LocalDateTime.of(2026, 4, 9, 14, 0)
+        val hourly = WeatherHourlyData(
+            time = listOf("2026-04-09T14:00"),
+            windSpeed10m = listOf(10.0),
+            windDirection10m = listOf(450.0),
+            precipitationProbability = listOf(0)
+        )
+
+        val result = weatherConditionsAt(hourly, target)
+
+        assertEquals(90, result!!.windDirectionDegrees)
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────

--- a/app/src/test/java/com/ryan/pollenwitan/ui/screens/ProfileEditViewModelTest.kt
+++ b/app/src/test/java/com/ryan/pollenwitan/ui/screens/ProfileEditViewModelTest.kt
@@ -243,6 +243,66 @@ class ProfileEditViewModelTest {
     }
 
     @Test
+    fun `validation rejects more reminder hours than times per day`() {
+        val state = makeState(
+            medicineAssignments = listOf(
+                makeAssignmentUi("med1", dose = "1", timesPerDay = "2", reminderHours = listOf(8, 14, 20))
+            )
+        )
+        val result = ProfileEditLogic.validate(state)
+        assertTrue(result is ProfileEditLogic.ValidationResult.Invalid)
+        assertEquals(
+            ProfileEditLogic.ValidationReason.TooManyReminderHours,
+            (result as ProfileEditLogic.ValidationResult.Invalid).reason
+        )
+    }
+
+    @Test
+    fun `validation accepts equal reminder hours and times per day`() {
+        val state = makeState(
+            medicineAssignments = listOf(
+                makeAssignmentUi("med1", dose = "1", timesPerDay = "3", reminderHours = listOf(8, 14, 20))
+            )
+        )
+        assertTrue(ProfileEditLogic.validate(state) is ProfileEditLogic.ValidationResult.Valid)
+    }
+
+    @Test
+    fun `validation accepts fewer reminder hours than times per day`() {
+        val state = makeState(
+            medicineAssignments = listOf(
+                makeAssignmentUi("med1", dose = "1", timesPerDay = "3", reminderHours = listOf(8))
+            )
+        )
+        assertTrue(ProfileEditLogic.validate(state) is ProfileEditLogic.ValidationResult.Valid)
+    }
+
+    @Test
+    fun `validation rejects out-of-range reminder hour`() {
+        val state = makeState(
+            medicineAssignments = listOf(
+                makeAssignmentUi("med1", dose = "1", timesPerDay = "1", reminderHours = listOf(24))
+            )
+        )
+        val result = ProfileEditLogic.validate(state)
+        assertTrue(result is ProfileEditLogic.ValidationResult.Invalid)
+        assertEquals(
+            ProfileEditLogic.ValidationReason.InvalidReminderHour,
+            (result as ProfileEditLogic.ValidationResult.Invalid).reason
+        )
+    }
+
+    @Test
+    fun `validation accepts midnight reminder hour`() {
+        val state = makeState(
+            medicineAssignments = listOf(
+                makeAssignmentUi("med1", dose = "1", timesPerDay = "1", reminderHours = listOf(0))
+            )
+        )
+        assertTrue(ProfileEditLogic.validate(state) is ProfileEditLogic.ValidationResult.Valid)
+    }
+
+    @Test
     fun `reminder hours are preserved in assignment`() {
         val assignments = listOf(
             makeAssignmentUi("med1", dose = "1", timesPerDay = "3", reminderHours = listOf(7, 13, 21))

--- a/tasks/release-1.2.0.md
+++ b/tasks/release-1.2.0.md
@@ -1,0 +1,121 @@
+# Release 1.2.0 Plan
+
+Feature-heavy minor release following the 1.1.1 dependency-bump patch.
+
+**Deferred to a later release:**
+- #9 Longer-term data view / export — app is ~1 month old; no user has meaningful long-term data yet.
+- #19 Symptom prediction — same reason; the ±20% similarity lookup needs a meaningful diary history to produce useful predictions.
+
+---
+
+## Wave 1 — Foundations & quick wins
+
+Land schema/data-layer changes together so there's a single Room migration step for users, and bank some fast UX wins.
+
+- [ ] **#14 — Dashboard: wind speed/direction & rain probability from Open-Meteo**
+  - [ ] Extend `data/remote/dto/AirQualityResponse.kt` with `wind_speed_10m`, `wind_direction_10m`, `precipitation_probability` (or hourly equivalents)
+  - [ ] Extend `domain/model/AirQualityData.kt` with the new fields
+  - [ ] Map fields through `data/repository/AirQualityRepository.kt`
+  - [ ] Add a compact weather-context row below the allergen cards on `ui/screens/DashboardScreen.kt`
+  - [ ] Use Material Symbols icons for wind/rain
+  - [ ] Graceful null handling (off-season / unavailable)
+  - [ ] Confirm no extra API calls — single existing daily fetch
+
+- [ ] **#86 — Free-text note on daily check-in**
+  - [ ] Add nullable `notes: String?` column to the diary entity
+  - [ ] Room migration (bundle with any other schema work in this wave)
+  - [ ] Add multi-line text field to the daily check-in screen
+  - [ ] Persist via existing repository
+  - [ ] Display the note on diary history items
+
+- [ ] **#108 — Pull-to-refresh gesture on Dashboard**
+  - [ ] Wrap dashboard content in `PullToRefreshBox` (Compose Material 3)
+  - [ ] Wire to the existing refresh action in `DashboardViewModel`
+  - [ ] Move the refresh button to the top of the screen, smaller (or remove if redundant)
+  - [ ] Verify pull state survives configuration change
+
+- [ ] **#87 — Dosage times: full 00:00–23:00 range + validation**
+  - [ ] Expand the hour chips from 06:00–22:00 to 00:00–23:00
+  - [ ] Add validation: cannot select more hours than the configured doses-per-day
+  - [ ] Disable / grey-out additional chips once the limit is reached
+  - [ ] Confirm save path rejects invalid combinations
+
+---
+
+## Wave 2 — Single-screen features
+
+Independent feature work, no shared dependencies with later waves.
+
+- [ ] **#13 — Pollen Calendar screen**
+  - [ ] Flesh out the existing `PollenCalendar` route (already in `Screen.kt`)
+  - [ ] Hardcoded climatology table for the 6 pollen types (curated reference values)
+  - [ ] Horizontal bar chart, one row per pollen type, Jan–Dec on x-axis
+  - [ ] Intensity gradient shading (low/moderate/high) per month
+  - [ ] Vertical "you are here" marker for the current month
+  - [ ] Tap a bar to surface a short pollen-type description
+  - [ ] Verify dark + light theme rendering
+  - [ ] Confirm side-drawer entry is wired up
+
+- [ ] **#17 — Smart notification timing**
+  - [ ] Add lead-time preference to `NotificationPrefsRepository` (default 90 min, range 30–180)
+  - [ ] In `worker/PollenCheckWorker.kt`, after each fetch find the highest-threshold allergen's peak hour
+  - [ ] Compute trigger time = peak − lead-time
+  - [ ] Fall back to static morning-briefing time if computed time would be earlier
+  - [ ] Persist next-trigger time so it survives app restart
+  - [ ] Handle peak-on-following-calendar-day correctly
+  - [ ] Off-season fallback (flat/null pollen → static time)
+  - [ ] Expose lead-time slider/dropdown in `SettingsScreen.kt`
+
+---
+
+## Wave 3 — Analytics layer
+
+Build shared aggregation helpers once, reuse across the digest and effectiveness features. Introduce a small `domain/analytics/` package rather than scattering logic across ViewModels.
+
+- [ ] **#15 — Weekly digest summary card**
+  - [ ] Create `domain/analytics/` package
+  - [ ] Aggregation helper: last-7-days average symptom severity, medication adherence %, worst day, best day, dominant allergen
+  - [ ] Per-profile, switches with active profile
+  - [ ] Handles partial weeks gracefully
+  - [ ] Empty state: "No data yet" when fewer than 1 day of diary entries
+  - [ ] Card placement on Dashboard (collapsed by default, expandable) — confirm with screen mock first
+  - [ ] Tap navigates to full Trends / history view
+
+- [ ] **#21 — Medication effectiveness tracking**
+  - [ ] Reuse aggregation layer from #15
+  - [ ] Per-medication breakdown: avg symptom score on days taken vs days not taken, % difference, n in each group
+  - [ ] Minimum sample size guard (≥5 days each side)
+  - [ ] "Not enough data" empty state below the threshold
+  - [ ] Calculation logic in `domain/analytics/`, NOT in ViewModel
+  - [ ] Render as "Medication effectiveness" card on Trends screen
+  - [ ] Results refresh after each new dose/diary entry
+
+---
+
+## Wave 4 — Surfacing insights
+
+Lands last because it depends on the discovery engine producing stable findings.
+
+- [ ] **#18 — Correlation insight chip on Dashboard**
+  - [ ] Confirm the discovery engine exposes a query API for high-confidence findings (pre-flight check before starting)
+  - [ ] Define confidence threshold for surfacing
+  - [ ] Render dismissible chip below allergen cards on Dashboard
+  - [ ] Chip text: "💡 Your sneezing correlates strongly with Birch pollen — tap to learn more"
+  - [ ] Tap navigates to discovery detail screen
+  - [ ] Per-insight dismissal persisted to DataStore (new repository or extension of existing prefs repo)
+  - [ ] Per-active-profile only
+  - [ ] Show at most one chip at a time; rotate on next app open if multiple findings exist
+  - [ ] No chip rendered when no actionable findings exist
+
+---
+
+## Release checklist
+
+- [ ] All wave items merged into `release/1.2.0`
+- [ ] Update `tasks/lessons.md` with anything learned during the release
+- [ ] Bump `versionName` to `1.2.0` and increment `versionCode` in `app/build.gradle.kts`
+- [ ] Draft `tasks/release-notes-1.2.0.md`
+- [ ] Annotated tag `v1.2.0`
+- [ ] Merge `release/1.2.0` → `master` (`--no-ff`)
+- [ ] GitHub Release with signed APK attached
+- [ ] Close milestone `rel/1.2.0`; move #9 and #19 to the next milestone

--- a/tasks/release-notes-1.1.1.md
+++ b/tasks/release-notes-1.1.1.md
@@ -1,0 +1,12 @@
+# PollenWitan 1.1.1
+
+## Bug fixes
+
+- **Cache miss on day rollover** ([#84](https://github.com/ryan-buttery/PollenWitan/issues/84)) — If the forecast cache was populated in the last hour of the previous day, the 1-hour TTL would still consider it fresh after midnight, but the cached timestamps no longer covered the current hour and the dashboard crashed. `getCurrentConditions` now silently forces a fresh API fetch on a cache miss before surfacing an error. The same path is used by the manual refresh button, so that flow is fixed too.
+
+## Dependency updates
+
+- `org.jetbrains.kotlin.plugin.serialization` 2.2.20 → 2.2.21
+- `androidx.activity:activity-compose` 1.9.3 → 1.13.0
+- `androidx.appcompat:appcompat` 1.7.0 → 1.7.1
+- `androidx.room:{room-runtime,room-ktx,room-compiler}` 2.8.3 → 2.8.4


### PR DESCRIPTION
…esh, dose hours

#14 Wind/rain on Dashboard: parallel fetch from Open-Meteo forecast endpoint, new WeatherForecastResponse DTO, WeatherConditions added to CurrentConditions, endpoint column added to cached_forecasts (MIGRATION_3_4) so air-quality and weather payloads share the table. Best-effort — weather failure leaves dashboard intact. WeatherContextCard rendered between pollen and discovery.

#86 Free-text note on daily check-in: nullable notes column on symptom_entries (MIGRATION_4_5), threaded through repository, view-model and check-in screen, displayed on diary cards.

#108 Pull-to-refresh on Dashboard: PullToRefreshBox wraps the success state, DashboardUiState.isRefreshing distinguishes initial load from background refresh, refresh failures preserve existing data, refresh button moved to a small header IconButton.

#87 Dosage times 00:00–23:00 + validation: hour chips now span the full day, toggle and validation cap selection at times-per-day, lowering times-per-day trims trailing reminder hours, new ValidationReason variants and unit tests.