### PR TITLE
Fix Gradle signing config crash when keystore.properties is missing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,7 @@ val keystoreProperties = Properties().apply {
         load(keystorePropertiesFile.inputStream())
     }
 }
+val hasReleaseKeystore = keystoreProperties.getProperty("storeFile")?.isNotBlank() == true
 
 android {
 namespace = "com.ryan.pollenwitan"
@@ -28,10 +29,12 @@ namespace = "com.ryan.pollenwitan"
 
     signingConfigs {
         create("release") {
-            storeFile = file(keystoreProperties.getProperty("storeFile", ""))
-            storePassword = keystoreProperties.getProperty("storePassword", "")
-            keyAlias = keystoreProperties.getProperty("keyAlias", "")
-            keyPassword = keystoreProperties.getProperty("keyPassword", "")
+            if (hasReleaseKeystore) {
+                storeFile = file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword", "")
+                keyAlias = keystoreProperties.getProperty("keyAlias", "")
+                keyPassword = keystoreProperties.getProperty("keyPassword", "")
+            }
         }
     }
 
@@ -40,7 +43,9 @@ namespace = "com.ryan.pollenwitan"
             isMinifyEnabled = false
             applicationIdSuffix = ".debug"
             resValue("string", "app_name", "PollenWitan (Debug)")
-            signingConfig = signingConfigs.getByName("release")
+            if (hasReleaseKeystore) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
         create("benchmark") {
             initWith(getByName("debug"))
@@ -52,7 +57,9 @@ namespace = "com.ryan.pollenwitan"
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+            if (hasReleaseKeystore) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             isDebuggable = true // Intentional: required for profiling with Android Studio
         }
         release {
@@ -63,7 +70,9 @@ namespace = "com.ryan.pollenwitan"
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+            if (hasReleaseKeystore) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Gradle configuration failed with `Cannot convert '' to File.` when `keystore.properties` was absent, causing local/CI builds to fail during project configuration.

### Description
- Add `val hasReleaseKeystore = keystoreProperties.getProperty("storeFile")?.isNotBlank() == true` and guard signing property assignment in `app/build.gradle.kts` so `storeFile`, `storePassword`, `keyAlias`, and `keyPassword` are only set when a release keystore is configured.
- Update `debug`, `benchmark`, and `release` build types to assign the custom `release` `signingConfig` only when `hasReleaseKeystore` is `true` to avoid resolving an empty file path.
- This prevents calling `file("")` during Gradle configuration while preserving existing behavior when `keystore.properties` is provided.

### Testing
- Ran `./gradlew build` and confirmed the original `Cannot convert '' to File.` configuration error is resolved.
- Continued `./gradlew build` in this environment fails later due to a missing Android SDK (`sdk.dir` / `ANDROID_HOME`), which is an unrelated environment issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee64b1ea6c8321a59e86913ef29338)